### PR TITLE
Delete the Specific Version dependency of GT6

### DIFF
--- a/src/main/java/vexatos/tgregworks/TGregworks.java
+++ b/src/main/java/vexatos/tgregworks/TGregworks.java
@@ -37,7 +37,7 @@ import vexatos.tgregworks.util.TGregUtils;
  */
 @Mod(modid = Mods.TGregworks, name = Mods.TGregworks_NAME, version = "@VERSION@",
 	dependencies = "required-after:" + Mods.TConstruct + "@[1.7.10-1.8.6b.build977,);"
-		+ "required-after:" + Mods.GregTech + "@[GT6-MC1710];"
+		+ "required-after:" + Mods.GregTech + ";"
 		+ "before:" + Mods.TiCTooltips + "@[1.2.4,)")
 public class TGregworks {
 


### PR DESCRIPTION
GT6U changes the mod version to GT6U-1710. This causes TGregwork to not be able to load with GT6U.