### PR TITLE
fixes NPE  missing material 

### DIFF
--- a/src/main/java/vexatos/tgregworks/integration/TGregRegistry.java
+++ b/src/main/java/vexatos/tgregworks/integration/TGregRegistry.java
@@ -78,7 +78,7 @@ public class TGregRegistry {
 		for(Materials m : toolMaterials) {
 			toolMaterialNames.add(m.mDefaultLocalName);
 			int matID = getMaterialID(m);
-			TConstructRegistry.addToolMaterial(matID, m.name(), m.mLocalizedName, m.mToolQuality,
+			TConstructRegistry.addToolMaterial(matID, m.name(), m.mDefaultLocalName, m.mToolQuality,
 				(int) (m.mDurability * getGlobalMultiplier(Config.Durability) * getMultiplier(m, Config.Durability)), // Durability
 				(int) (m.mToolSpeed * 100F * getGlobalMultiplier(Config.MiningSpeed) * getMultiplier(m, Config.MiningSpeed)), // Mining speed
 				(int) (m.mToolQuality * getGlobalMultiplier(Config.Attack) * getMultiplier(m, Config.Attack)), // Attack

--- a/src/main/java/vexatos/tgregworks/item/ItemTGregPart.java
+++ b/src/main/java/vexatos/tgregworks/item/ItemTGregPart.java
@@ -151,7 +151,7 @@ public class ItemTGregPart extends CraftingItem implements IToolPart {
 		Materials m = Materials.get(data.getString("material"));
 		if(m != null) {
 			Integer matID = TGregworks.registry.matIDs.get(m);
-			if(matID != stack.getItemDamage()) {
+			if(matID != null && matID != stack.getItemDamage()) {
 				stack.setItemDamage(matID);
 			}
 		}

--- a/src/main/java/vexatos/tgregworks/item/ItemTGregPart.java
+++ b/src/main/java/vexatos/tgregworks/item/ItemTGregPart.java
@@ -48,7 +48,7 @@ public class ItemTGregPart extends CraftingItem implements IToolPart {
 		if(!data.hasKey("material") || Materials.get(data.getString("material")) == Materials._NULL) {
 			matName = StatCollector.translateToLocal("tgregworks.materials.unknown");
 		} else {
-			matName = Materials.get(data.getString("material")).mLocalizedName;
+			matName = Materials.get(data.getString("material")).mDefaultLocalName;
 		}
 
 		String name = StatCollector.translateToLocal("tgregworks.toolpart." + type.getPartName().replace(" ", "_").toLowerCase());


### PR DESCRIPTION
This fixes the NPE that Prometheus0000 was getting, and the world will load. But Tinker's tools made with the missing material will now become a super-bugged item, which doesn't show Tinker's tooltips and will crash the game if you do anything that would give it XP, or if you force it to show a tooltip.