### PR TITLE
Swapping parts instead of repairing for AmmoItems

### DIFF
--- a/src/main/java/vexatos/tgregworks/integration/iguanatweakstconstruct/ModTGregPartReplacement.java
+++ b/src/main/java/vexatos/tgregworks/integration/iguanatweakstconstruct/ModTGregPartReplacement.java
@@ -13,6 +13,7 @@ import tconstruct.library.modifier.ItemModifier;
 import tconstruct.library.tools.DualMaterialToolPart;
 import tconstruct.library.tools.ToolCore;
 import tconstruct.library.util.IToolPart;
+import tconstruct.library.weaponry.AmmoItem;
 import tconstruct.tools.TinkerTools;
 import tconstruct.weaponry.TinkerWeaponry;
 import vexatos.tgregworks.integration.recipe.tconstruct.TGregToolRecipe;
@@ -52,6 +53,10 @@ public class ModTGregPartReplacement extends ItemModifier {
 		if(tags.getInteger("Damage") > 0) {
 			return false;
 		}
+
+		// Durability is written on "Ammo" tag instead of "Damage" tag for AmmoWeapons
+		if (tool instanceof AmmoItem && ((AmmoItem) tool).getMaxAmmo(tags) != ((AmmoItem) tool).getAmmoCount(itemStack))
+			return false;
 
 		// check if any of the tools parts contain stone. we have to prevent exchanging that with disabled stone tools
 		// because otherwise the replacement-logic would not be able to obtain necessary information and crash.


### PR DESCRIPTION
Because AmmoItem durabilities are held in "Ammo" key and not in "Damage" as other tools, it wasn't checking for it in the replacement logic and replacing tool parts instead of repairing them, this is mainly issue with items that can be repaired with a valid tool material for example a throwing knife with bone head and wooden stick, would become bone head with bone stick instead of getting its ammo replenished.

This needs similar PRs to IguanaTweaks-GTNH and TinkersConstruct-GTNH mods, but they shouldnt be needed for this to be merged so I'll not link them here.

It would also solve this issue if this and aforementioned PRs gets merged, https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/24330

I tested this in latest daily but it was hard for me to build this mod specifically so probably a second eye could be good though I doubt this would break anything.