### PR TITLE
Use key to register materials

### DIFF
--- a/src/main/java/vexatos/tgregworks/integration/TGregRegistry.java
+++ b/src/main/java/vexatos/tgregworks/integration/TGregRegistry.java
@@ -102,7 +102,7 @@ public class TGregRegistry {
 	}
 
 	public void addToolMaterial(int matID, Materials m) {
-		TConstructRegistry.addToolMaterial(matID, m.getName(), m.getLocalizedName(), m.mToolQuality,
+		TConstructRegistry.addToolMaterial(matID, m.getName(), m.getLocalizedNameKey(), m.mToolQuality,
 			(int) (m.mDurability * getGlobalMultiplier(Config.Durability) * getMultiplier(m, Config.Durability)), // Durability
 			(int) (m.mToolSpeed * 100F * getGlobalMultiplier(Config.MiningSpeed) * getMultiplier(m, Config.MiningSpeed)), // Mining speed
 			(int) (m.mToolQuality * getGlobalMultiplier(Config.Attack) * getMultiplier(m, Config.Attack)), // Attack


### PR DESCRIPTION
addToolMaterial should accept the material's translation key, not the localized name. 

this solves the issue where the material's name remains in the original language after switching languages in the game.